### PR TITLE
Fix Culture dependent string conversions

### DIFF
--- a/MyceliumNetworkingForCW/MyceliumNetwork.cs
+++ b/MyceliumNetworkingForCW/MyceliumNetwork.cs
@@ -1,6 +1,7 @@
 ﻿using Steamworks;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -372,7 +373,9 @@ namespace MyceliumNetworking
 				RugLogger.LogWarning($"Accessing lobby data for unregistered key '{key}'. This might not exist.");
 			}
 
-			if(!SteamMatchmaking.SetLobbyData(Lobby, key, value.ToString()))
+            
+
+            if (!SteamMatchmaking.SetLobbyData(Lobby, key, (string)Convert.ChangeType(value, typeof(string), CultureInfo.InvariantCulture)))
 			{
 				RugLogger.LogError("Error setting lobby data.");
 			}
@@ -424,7 +427,7 @@ namespace MyceliumNetworking
 
 			try
 			{
-				return (T)Convert.ChangeType(value, typeof(T));
+				return (T)Convert.ChangeType(value, typeof(T), CultureInfo.InvariantCulture);
 			}
 			catch(Exception ex)
 			{
@@ -452,7 +455,7 @@ namespace MyceliumNetworking
 				RugLogger.LogWarning($"Accessing player data for unregistered key '{key}'. This might not exist.");
 			}
 
-			SteamMatchmaking.SetLobbyMemberData(Lobby, key.ToString(), value.ToString());
+			SteamMatchmaking.SetLobbyMemberData(Lobby, key.ToString(), (string)Convert.ChangeType(value, typeof(string), CultureInfo.InvariantCulture));
 		}
 
 		/// <summary>
@@ -503,7 +506,7 @@ namespace MyceliumNetworking
 			{
 				try
 				{
-					return (T)Convert.ChangeType(value, typeof(T));
+					return (T)Convert.ChangeType(value, typeof(T), CultureInfo.InvariantCulture);
 				}
 				catch(Exception ex)
 				{

--- a/MyceliumNetworkingForCW/MyceliumNetwork.cs
+++ b/MyceliumNetworkingForCW/MyceliumNetwork.cs
@@ -373,8 +373,6 @@ namespace MyceliumNetworking
 				RugLogger.LogWarning($"Accessing lobby data for unregistered key '{key}'. This might not exist.");
 			}
 
-            
-
             if (!SteamMatchmaking.SetLobbyData(Lobby, key, (string)Convert.ChangeType(value, typeof(string), CultureInfo.InvariantCulture)))
 			{
 				RugLogger.LogError("Error setting lobby data.");

--- a/MyceliumNetworkingForCW/MyceliumNetworkingForCW.csproj
+++ b/MyceliumNetworkingForCW/MyceliumNetworkingForCW.csproj
@@ -91,12 +91,12 @@
 
   <!-- References - Game Assemblies -->
   <ItemGroup Condition="$(CI) != 'true'">
-	<Reference Include="Assembly-CSharp" Publicize="true" Private="false">
-		<HintPath>$(CW_References)Assembly-CSharp.dll</HintPath>
-	</Reference>
-	<Reference Include="Steamworks.NET" Private="false">
-      <HintPath>$(CW_References)com.rlabrecque.steamworks.net.dll</HintPath>
-    </Reference>
+	  <Reference Include="Assembly-CSharp" Publicize="true" Private="false">
+		  <HintPath>$(ManagedDirectory)Assembly-CSharp.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Steamworks.NET" Private="false">
+		  <HintPath>$(ManagedDirectory)com.rlabrecque.steamworks.net.dll</HintPath>
+	  </Reference>
   </ItemGroup>
 
   <!-- Package References - Game Assemblies -->

--- a/MyceliumNetworkingForCW/MyceliumNetworkingForCW.csproj
+++ b/MyceliumNetworkingForCW/MyceliumNetworkingForCW.csproj
@@ -91,11 +91,11 @@
 
   <!-- References - Game Assemblies -->
   <ItemGroup Condition="$(CI) != 'true'">
-    <Reference Include="Assembly-CSharp" Publicize="true" Private="false">
-      <HintPath>$(ManagedDirectory)Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Steamworks.NET" Private="false">
-      <HintPath>$(ManagedDirectory)com.rlabrecque.steamworks.net.dll</HintPath>
+	<Reference Include="Assembly-CSharp" Publicize="true" Private="false">
+		<HintPath>$(CW_References)Assembly-CSharp.dll</HintPath>
+	</Reference>
+	<Reference Include="Steamworks.NET" Private="false">
+      <HintPath>$(CW_References)com.rlabrecque.steamworks.net.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Tested with `en-US CultureInfo` to `ru-RU CultureInfo` and vice-versa with help from [Cyclozarin](https://github.com/cyclozarin). Was tested with `float`s, `int`s and `boolean`s, so it should work with other values as this only implements `CultureInfo` for conversions to string and back

- Changes: Some `object.ToString` were changed to `Convert.ChangeType` with a `conversionType` of `string` as `object.ToString` does not seem to have a parameter for `CultureInfo`
- Changes: All `Convert.ChangeType` to have a `CultureInfo.InvariantCulture` parameter